### PR TITLE
Refact control options

### DIFF
--- a/src/cocaine/burlak/chcache.py
+++ b/src/cocaine/burlak/chcache.py
@@ -84,11 +84,11 @@ class ChannelsCache(object):
 
     @gen.coroutine
     def close_other(self, to_retain_set):
-        '''
+        """
         params:
             to_retain_set - should stay in cache, other channels would be
                             deleted
-        '''
+        """
         to_close = self.channels.viewkeys() - to_retain_set
         yield self.close_and_remove(to_close)
 

--- a/src/cocaine/burlak/config.py
+++ b/src/cocaine/burlak/config.py
@@ -266,10 +266,12 @@ class Config(object):
             'type': 'boolean',
             'required': False,
         },
+        # TODO(Config): deprecated, remove!
         'stop_by_control': {
             'type': 'boolean',
             'required': False,
         },
+        # TODO(Config): deprecated, remove!
         'control_with_ack': {
             'type': 'boolean',
             'required': False,
@@ -449,10 +451,6 @@ class Config(object):
             Defaults.STOP_APPS_NOT_IN_STATE)
 
     @property
-    def stop_by_control(self):
-        return self._config.get('stop_by_control', Defaults.STOP_BY_CONTROL)
-
-    @property
     def sentry_dsn(self):
         return self._config.get('sentry_dsn', Defaults.SENTRY_DSN)
 
@@ -521,10 +519,6 @@ class Config(object):
     def sharding(self):
         sharding = self._config.get('sharding', {})
         return make_sharding_config(sharding)
-
-    @property
-    def control_with_ack(self):
-        return self._config.get('control_with_ack', Defaults.CONTROL_WITH_ACK)
 
     @property
     def control_filter_path(self):

--- a/tests/common.py
+++ b/tests/common.py
@@ -30,6 +30,14 @@ def make_mock_channels_list_with(sequence):
     return [make_future(MockChannel(v)) for v in sequence]
 
 
+def make_mock_control_channel_with(*v):
+    return make_future(MockControlChannel(*v))
+
+
+def make_mock_control_list_with(sequence):
+    return [make_mock_control_channel_with([v]) for v in sequence]
+
+
 def make_logger_mock(mocker):
     logger = mocker.Mock()
 
@@ -47,5 +55,19 @@ class MockChannel(object):
         self.rx.get = mock.Mock(side_effect=[make_future(v) for v in values])
 
         self.tx = mock.Mock()
+
         self.tx.write = mock.Mock(return_value=make_future(0))
+        self.tx.close = mock.Mock(return_value=make_future(0))
+
+
+class MockControlChannel(object):
+    def __init__(self, *values):
+        self.rx = mock.Mock()
+        self.rx.get = \
+            mock.Mock(side_effect=[make_future(0) for v in values])
+
+        self.tx = mock.Mock()
+
+        self.tx.write = mock.Mock(
+            return_value=make_mock_channels_list_with(*values))
         self.tx.close = mock.Mock(return_value=make_future(0))

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -248,7 +248,6 @@ def test_get_state_by_app(http_client, base_url, is_legacy, state_path):
         state = loaded_state if is_legacy else loaded_state.get('state', {})
 
         assert response.code == 200
-        print 'app {} body {}'.format(app, response.body)
         assert state == {app: test_state[app]._asdict()}
 
 


### PR DESCRIPTION
Deprecates options:
 - stop_by_control (always use control to stop apps)
 - control_with_ack (ack always applied)