### PR TITLE
Network metrics in feedback

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-orca (0.1.43) unstable; urgency=medium
+
+  * System network metrics in feedback.
+
+ -- Alex Karev <karapuz@karapuz-ub14>  Wed, 11 Jul 2018 20:28:26 +0300
+
 cocaine-orca (0.1.42) unstable; urgency=medium
 
   * Restart applications in broken state.

--- a/src/cocaine/burlak/burlak.py
+++ b/src/cocaine/burlak/burlak.py
@@ -1031,7 +1031,7 @@ class AppsElysium(LoggerMixin, MetricsMixin, LoopSentry):
                 message="can't start app",
                 extra=dict(
                     app=app,
-                    profile=profile
+                    profile=profile,
                 ),
             )
 

--- a/src/cocaine/burlak/burlak.py
+++ b/src/cocaine/burlak/burlak.py
@@ -16,7 +16,7 @@
 import time
 
 from cocaine.exceptions import ServiceError
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from datetime import timedelta
 
 from cerberus import Validator

--- a/src/cocaine/burlak/config.py
+++ b/src/cocaine/burlak/config.py
@@ -330,6 +330,10 @@ class Config(object):
                 ],
             },
         },
+        'netlink_speed_mb': {  # in megabits!
+            'type': 'integer',
+            'required': False,
+        },
         'control_filter_path': {
             'type': 'string',
             'required': False,
@@ -529,6 +533,13 @@ class Config(object):
         d = self._config.get('control_filter', dict())
         return ControlFilter.from_dict(d)
 
+    @control_filter.setter
+    def control_filter(self, control_filter):
+        self._config['control_filter'] = dict(
+            apply_control=control_filter.apply_control,
+            white_list=control_filter.white_list
+        )
+
     @property
     def api_timeout(self):
         return self._config.get('api_timeout_sec', Defaults.API_TIMEOUT)
@@ -549,12 +560,17 @@ class Config(object):
     def procfs_loadavg_name(self):
         return Defaults.PROCFS_LOADAVG
 
-    @control_filter.setter
-    def control_filter(self, control_filter):
-        self._config['control_filter'] = dict(
-            apply_control=control_filter.apply_control,
-            white_list=control_filter.white_list
-        )
+    @property
+    def procfs_netstat_name(self):
+        return Defaults.PROCFS_NETSTAT
+
+    @property
+    def sysfs_network_prefix(self):
+        return Defaults.SYSFS_NET_PREFIX
+
+    @property
+    def netlink_speed_mb(self):
+        return self._config.get('netlink_speed_mb', Defaults.NETLINK_SPEED_MB)
 
     # TODO:
     #   refactor to single method?

--- a/src/cocaine/burlak/config.py
+++ b/src/cocaine/burlak/config.py
@@ -3,9 +3,9 @@ import os
 
 import cerberus
 
-import yaml
-
 from collections import namedtuple
+
+import yaml
 
 from .control_filter import ControlFilter
 from .defaults import Defaults
@@ -330,8 +330,12 @@ class Config(object):
                 ],
             },
         },
-        'netlink_speed_mb': {  # in megabits!
+        'netlink_speed_mbits': {  # in megabits!
             'type': 'integer',
+            'required': False,
+        },
+        'netlink_default_name': {
+            'type': 'string',
             'required': False,
         },
         'control_filter_path': {
@@ -549,19 +553,19 @@ class Config(object):
         return 2 * self._config.get('api_timeout_sec', Defaults.API_TIMEOUT)
 
     @property
-    def procfs_stat_name(self):
+    def procfs_stat_path(self):
         return Defaults.PROCFS_STAT
 
     @property
-    def procfs_mem_name(self):
+    def procfs_mem_path(self):
         return Defaults.PROCFS_MEMINFO
 
     @property
-    def procfs_loadavg_name(self):
+    def procfs_loadavg_path(self):
         return Defaults.PROCFS_LOADAVG
 
     @property
-    def procfs_netstat_name(self):
+    def procfs_netstat_path(self):
         return Defaults.PROCFS_NETSTAT
 
     @property
@@ -569,8 +573,13 @@ class Config(object):
         return Defaults.SYSFS_NET_PREFIX
 
     @property
-    def netlink_speed_mb(self):
-        return self._config.get('netlink_speed_mb', Defaults.NETLINK_SPEED_MB)
+    def netlink_speed_mbits(self):
+        return self._config.get(
+            'netlink_speed_mbits', Defaults.NETLINK_SPEED_MBITS)
+
+    @property
+    def netlink_default_name(self):
+        return self._config.get('netlink_default_name', Defaults.NETLINK_NAME)
 
     # TODO:
     #   refactor to single method?

--- a/src/cocaine/burlak/defaults.py
+++ b/src/cocaine/burlak/defaults.py
@@ -76,4 +76,5 @@ class Defaults(object):
 
     SYSFS_NET_PREFIX = '/sys/class/net'
 
-    NETLINK_SPEED_MB = 10000  # Megabits
+    NETLINK_SPEED_MBITS = 10000  # Megabits
+    NETLINK_NAME = 'veth0'

--- a/src/cocaine/burlak/defaults.py
+++ b/src/cocaine/burlak/defaults.py
@@ -71,3 +71,9 @@ class Defaults(object):
     PROCFS_STAT = '/proc/stat'
     PROCFS_MEMINFO = '/proc/meminfo'
     PROCFS_LOADAVG = '/proc/loadavg'
+
+    PROCFS_NETSTAT = '/proc/net/dev'
+
+    SYSFS_NET_PREFIX = '/sys/class/net'
+
+    NETLINK_SPEED_MB = 10000  # Megabits

--- a/src/cocaine/burlak/metrics/fetcher.py
+++ b/src/cocaine/burlak/metrics/fetcher.py
@@ -1,3 +1,4 @@
+"""Metrics fetcher abstraction."""
 import time
 
 from tornado import gen
@@ -6,12 +7,13 @@ from ..mixins import LoggerMixin
 
 
 class MetricsFetcher(LoggerMixin):
-    """Basic metrics provider
+    """Basic metrics provider.
 
     Includes metrics:
         system - memory, cpu load, ect
         applications - TBD
     """
+
     def __init__(self, context, system_metrics, **kwargs):
         super(MetricsFetcher, self).__init__(context, **kwargs)
 
@@ -19,7 +21,7 @@ class MetricsFetcher(LoggerMixin):
 
     @gen.coroutine
     def fetch(self, _query, _type="tree"):
-        """Try to mimic Cocaine metrics service API
+        """Try to mimic Cocaine metrics service API.
 
         Note that API very likely subject of changes!
         """

--- a/src/cocaine/burlak/metrics/procfs.py
+++ b/src/cocaine/burlak/metrics/procfs.py
@@ -3,6 +3,9 @@
 Links:
  - read `man 5 proc` for procfs stat files formats.
 """
+import itertools
+import six
+
 from collections import namedtuple
 
 from tornado import gen
@@ -15,7 +18,11 @@ from ..mixins import LoggerMixin
 
 # Time to async sleep between two cpu load measurements
 CPU_POLL_TICK = .25  # 250ms
+NET_POLL_TICK = .25  # 250ms
+NET_TICKS_PER_SEC = 1. / NET_POLL_TICK
+
 CPU_FIELDS_COUNT = 11  # one label field "cpu" + 10 ticks fields
+NET_FIELDS_COUNT = 17
 
 
 class ProcfsMetric(object):
@@ -44,6 +51,16 @@ class ProcfsMetric(object):
         try:
             self._file.seek(0)
             return [self._file.readline() for _ in xrange(to_read)]
+        except Exception as e:
+            self.reopen()
+            raise
+
+    def read_all_lines(self, to_skip=0):
+        """Read all lines from start of file until first non empty found."""
+        try:
+            self._file.seek(0)
+            _ = [self._file.readline() for _ in xrange(to_skip)]
+            return [ln for ln in self._file]
         except Exception as e:
             self.reopen()
             raise
@@ -275,3 +292,176 @@ class Memory(ProcfsMetric):
             used = used - cached
 
         return clamp(used / float(total), .0, 1.0)
+
+
+class IfSpeed(ProcfsMetric):
+    """Read NIC speed from sysfs.
+
+    TODO(IfSpeed): Deprecated: it seems that there is no any portable way
+    to get real network speed bandwidth, e.g. for kvm
+        sysfs:/sys/class/network/*/speed
+    could be unavailable (is is useless here), or it could be set incorrectly
+    for virtual interfaces in container (arguable, needs investigation).
+    """
+    SYSFS_FNAME = 'speed'
+
+    def __init__(self, path):
+        """Init procfs network metric with specified path."""
+        super(IfSpeed, self).__init__(path)
+
+    @gen.coroutine
+    def read(self):
+        """Read netlink speed in Mbs."""
+        return IfSpeed._parse(self.read_nfirst_lines())
+
+    @staticmethod
+    def _parse(lines):
+        return int(lines[0])
+
+    @staticmethod
+    def make_path(prefix, iface):
+        """Construct sysfs path for iface speed file."""
+        return '{}/{}/{}'.format(prefix, iface, IfSpeed.SYSFS_FNAME)
+
+
+class Network(ProcfsMetric):
+    """Read network stat from /proc/net/dev.
+
+    TODO: it should be configurable interfaces name (prefix) or way to obtain
+    correct config, not `node_summary` and error prone IGNORE_LIST_PFX checks.
+    Seems that interface along with speed limit should be set by admin
+    explicitly in config, as we don't have raliable way to obtain it from
+    container.
+    """
+
+    #     0
+    # Iface,
+    #        1         2       3         4        5         6       7      8
+    #    bytes,  packets, errors,    drops,    fifo,    frame,   comp, mcast,
+    #                                                                     16
+    IF_NAME, \
+        RX_BTS, RX_PCKS, RX_ERR, RX_DROPS, RX_FIFO, RX_FRAME, RX_CMP, RX_MC, \
+        TX_BTS, TX_PCKS, TX_ERR, TX_DROPS, TX_FIFO, TX_FRAME, TX_CMP, TX_MC  \
+        = xrange(NET_FIELDS_COUNT)
+
+    IGNORE_LIST_PFX = {'lo', 'tun', 'dummy', 'wlan', 'docker', 'br'}
+    UNKNOWN_SPEED = -1
+
+    Net = namedtuple('Net', 'speed_mbits rx tx rx_delta tx_delta')
+
+    def __init__(self, path, sysfs_path_pfx, netlink_speed_mb):
+        """Init procfs network metric with specified path."""
+        super(Network, self).__init__(path)
+
+        self._netlink_speed_mb = netlink_speed_mb
+        self._speed_file_pfx = sysfs_path_pfx
+        self._speed_files_cache = {}
+
+    @gen.coroutine
+    def read(self):
+        """Read network stat from procfs.
+
+        :return: dictionary of inftercase with their stat
+        :rtype: dict[str, Network.Net]
+        """
+        network1 = Network._parse(self.read_all_lines(to_skip=2))
+        yield gen.sleep(NET_POLL_TICK)
+        network2 = Network._parse(self.read_all_lines(to_skip=2))
+
+        to_process = [
+            (iface, network1[iface], network2[iface])
+            for iface in network1 if iface in network2
+        ]
+
+        results = {}
+        for (iface, net1, net2) in to_process:
+
+            drx = int(NET_TICKS_PER_SEC * (net2.rx - net1.rx))
+            dtx = int(NET_TICKS_PER_SEC * (net2.tx - net1.tx))
+
+            if_speed = Network.UNKNOWN_SPEED
+
+            try:
+                if_speed = yield self._get_link_speed(iface)
+            except Exception as e:
+                # probably no sysfs on node, ignore silently
+                pass
+
+            results[iface] = Network.Net(if_speed, net2.rx, net2.tx, drx, dtx)
+
+        #
+        # Count summary for all active interfaces.
+        # Note that some ifaces stats could be included in some other,
+        # so it is possibility of overcount, correct accounting is subject
+        # of further investigation.
+        #
+        summary_rx, summary_tx, delta_rx, delta_tx, max_speed = 0, 0, 0, 0, 0
+        for net in six.itervalues(results):
+            summary_rx += net.rx
+            summary_tx += net.tx
+
+            delta_rx += net.rx_delta
+            delta_tx += net.tx_delta
+
+            if net.speed_mbits > max_speed:
+                max_speed = net.speed_mbits
+
+        if max_speed <= 0:  # e.g. KVM
+            max_speed = self._netlink_speed_mb
+
+        results['node_summary'] = Network.Net(
+            max_speed,
+            summary_rx,
+            summary_tx,
+            delta_rx,
+            delta_tx,
+        )
+
+        raise gen.Return(results)
+
+    @gen.coroutine
+    def _get_link_speed(self, iface):
+        """Temporary stub for iface speed acquisition.
+
+        TODO(profs.Network): should be redesign as it is no portable way to
+        aqcuire link speed.
+        """
+        if iface not in self._speed_files_cache:
+            path = IfSpeed.make_path(self._speed_file_pfx, iface)
+            self._speed_files_cache[iface] = IfSpeed()
+
+        speed = yield self._speed_files_cache[iface].read()
+        raise gen.Return(speed)
+
+    @staticmethod
+    def _parse(lines):
+        def in_black_list(s):
+            return any(s.startswith(pfx) for pfx in Network.IGNORE_LIST_PFX)
+
+        result = {}
+        lines = [ln.strip() for ln in lines]
+
+        for ln in itertools.ifilter(lambda s: not in_black_list(s), lines):
+            net_info = ln.split()
+
+            # remove colon from iface name
+            net_info[Network.IF_NAME] = net_info[Network.IF_NAME][:-1]
+
+            result[net_info[Network.IF_NAME]] = Network.Net(
+                Network.UNKNOWN_SPEED,
+                int(net_info[Network.RX_BTS]),
+                int(net_info[Network.TX_BTS]),
+                0,
+                0,
+            )
+
+        return result
+
+    @staticmethod
+    def as_named_dict(d):
+        """Convert mapping of namedtuples to dictionary of dictionaries."""
+        result = {}
+        for iface in d:
+            result[iface] = d[iface]._asdict()
+
+        return result

--- a/src/cocaine/burlak/metrics/procfs.py
+++ b/src/cocaine/burlak/metrics/procfs.py
@@ -428,7 +428,7 @@ class Network(ProcfsMetric):
         """
         if iface not in self._speed_files_cache:
             path = IfSpeed.make_path(self._speed_file_pfx, iface)
-            self._speed_files_cache[iface] = IfSpeed()
+            self._speed_files_cache[iface] = IfSpeed(path)
 
         speed = yield self._speed_files_cache[iface].read()
         raise gen.Return(speed)

--- a/src/cocaine/burlak/metrics/procfs.py
+++ b/src/cocaine/burlak/metrics/procfs.py
@@ -59,8 +59,7 @@ class ProcfsMetric(object):
         """Read all lines from start of file until first non empty found."""
         try:
             self._file.seek(0)
-            _ = [self._file.readline() for _ in xrange(to_skip)]
-            return [ln for ln in self._file]
+            return self._file.readlines()[to_skip:]
         except Exception as e:
             self.reopen()
             raise
@@ -349,13 +348,16 @@ class Network(ProcfsMetric):
 
     Net = namedtuple('Net', 'speed_mbits rx tx rx_delta tx_delta')
 
-    def __init__(self, path, sysfs_path_pfx, netlink_speed_mb):
+    def __init__(
+            self,
+            path, sysfs_path_pfx, default_netlink, netlink_speed_mbits):
         """Init procfs network metric with specified path."""
         super(Network, self).__init__(path)
 
-        self._netlink_speed_mb = netlink_speed_mb
+        self._netlink_speed_mbits = netlink_speed_mbits
         self._speed_file_pfx = sysfs_path_pfx
         self._speed_files_cache = {}
+        self._default_netlink = default_netlink
 
     @gen.coroutine
     def read(self):
@@ -387,6 +389,11 @@ class Network(ProcfsMetric):
                 # probably no sysfs on node, ignore silently
                 pass
 
+            if iface == self._default_netlink:
+                results['node_default'] = \
+                    Network.Net(
+                        self._netlink_speed_mbits, net2.rx, net2.tx, drx, dtx)
+
             results[iface] = Network.Net(if_speed, net2.rx, net2.tx, drx, dtx)
 
         #
@@ -407,7 +414,7 @@ class Network(ProcfsMetric):
                 max_speed = net.speed_mbits
 
         if max_speed <= 0:  # e.g. KVM
-            max_speed = self._netlink_speed_mb
+            max_speed = self._netlink_speed_mbits
 
         results['node_summary'] = Network.Net(
             max_speed,
@@ -460,8 +467,4 @@ class Network(ProcfsMetric):
     @staticmethod
     def as_named_dict(d):
         """Convert mapping of namedtuples to dictionary of dictionaries."""
-        result = {}
-        for iface in d:
-            result[iface] = d[iface]._asdict()
-
-        return result
+        return {iface: net._asdict() for iface, net in six.iteritems(d)}

--- a/src/cocaine/burlak/metrics/system.py
+++ b/src/cocaine/burlak/metrics/system.py
@@ -20,13 +20,14 @@ class SystemMetrics(LoggerMixin):
         self._config = context.config
 
         # System metrics
-        self._cpu = ProcfsCPU(context.config.procfs_stat_name)
-        self._memory = ProcfsMemory(context.config.procfs_mem_name)
-        self._loadavg = ProcfsLoadavg(context.config.procfs_loadavg_name)
+        self._cpu = ProcfsCPU(context.config.procfs_stat_path)
+        self._memory = ProcfsMemory(context.config.procfs_mem_path)
+        self._loadavg = ProcfsLoadavg(context.config.procfs_loadavg_path)
         self._network = ProcfsNetwork(
-            context.config.procfs_netstat_name,
+            context.config.procfs_netstat_path,
             context.config.sysfs_network_prefix,
-            context.config.netlink_speed_mb,
+            context.config.netlink_default_name,
+            context.config.netlink_speed_mbits,
         )
 
     @gen.coroutine


### PR DESCRIPTION
Collect and report via feedback procfs net stat: tx, rx, plus delta per second for separate interfaces and summary. Link speed could be acquired via sysfs (would be changed to more strict method, probably would be set in config by admins).

Recommended way to set link speed is to set it in config with _netlink_speed_mbits_ option.