### PR TITLE
Fix: sysfs files leak

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-orca (0.1.48) unstable; urgency=medium
+
+  * Fix: sysfs file leaks.
+
+ -- Alex Karev <karapuz@yandex-team.ru>  Wed, 12 Sep 2018 16:01:46 +0300
+
 cocaine-orca (0.1.47) unstable; urgency=medium
 
   * Take cluster-wide 'semaphore' type lock for applications startup.

--- a/src/cocaine/burlak/metrics/procfs.py
+++ b/src/cocaine/burlak/metrics/procfs.py
@@ -2,6 +2,9 @@
 
 Links:
  - read `man 5 proc` for procfs stat files formats.
+
+TODO(procfs): some logs would be helpful.
+
 """
 import itertools
 import six
@@ -395,6 +398,13 @@ class Network(ProcfsMetric):
         results = {}
         for iface, net in six.iteritems(networks):
             self._fill_results(results, iface, net)
+
+        to_close = \
+            six.viewkeys(self._speed_files_cache) - six.viewkeys(networks)
+
+        for iface in to_close:
+            self._speed_files_cache[iface].close()
+            self._speed_files_cache.pop(iface, {})
 
         return results
 


### PR DESCRIPTION
Files for all dynamically attached netlink interfaces was cached forever. Code for these PR will close removed from procfs interfaces.